### PR TITLE
Update Docker Hub source URL

### DIFF
--- a/charts/netobserv/Chart.yaml
+++ b/charts/netobserv/Chart.yaml
@@ -13,7 +13,7 @@ keywords:
 
 sources:
   - https://github.com/elastiflow/helm-chart-netobserv
-  - https://hub.docker.com/r/elastiflow/flowcollector/
+  - https://hub.docker.com/r/elastiflow/flow-collector/
 maintainers:
   - name: ElastiFlow Engineering Team
     email: engineering@elastiflow.com


### PR DESCRIPTION
## Summary
- update Docker Hub source link in Chart.yaml

## Testing
- `pre-commit run --files charts/netobserv/Chart.yaml`
- `yamllint -c lintconf.yaml charts/netobserv/Chart.yaml`

------
https://chatgpt.com/codex/tasks/task_e_684d1c9009bc8324ab773968cf3c61ae