### PR TITLE
Fix typos in values.yaml

### DIFF
--- a/charts/netobserv/values.yaml
+++ b/charts/netobserv/values.yaml
@@ -28,7 +28,7 @@ outputElasticsearch:
   enabled: false
   # Secret name to be used for the Elasticsearch password. If empty, the secret name defaults to `elasticsearch-es-elastic-user`
   secretRef: "elasticsearch-es-elastic-user"
-  # The key in the kubernetes scret that contains the Elasticsearch password.
+  # The key in the kubernetes secret that contains the Elasticsearch password.
   secretKey: elastic
   tls:
     # Enable/disable TLS connections to Elasticsearch.
@@ -52,7 +52,7 @@ outputOpenSearch:
   enabled: false
   # Secret name to be used for the OpenSearch password. If empty, the secret name defaults to `opensearch-es-elastic-user`
   secretRef: "opensearch-user"
-  # The key in the kubernetes scret that contains the OpenSearch password.
+  # The key in the kubernetes secret that contains the OpenSearch password.
   secretKey: opensearch-password
   tls:
     # Enable/disable TLS connections to OpenSearch.
@@ -94,7 +94,7 @@ license:
   # Specifies whether a secret should be created. If you don't have a license, no need to create a license secret.
   createSecret: false
   # Secret name to be used for the license. If empty, the secret name defaults to `netobserv-license`
-  # If no secret with a matching name exists, the value will be set from `licenseKey`.instead.
+  # If no secret with a matching name exists, the value will be set from `licenseKey` instead.
   secretRef: "netobserv-license"
   # Set account id
   accountId: ""
@@ -104,13 +104,13 @@ license:
   licenseKey: ""
 
 # If the EF_PROCESSOR_ENRICH_IPADDR_MAXMIND_ASN_ENABLE or EF_PROCESSOR_ENRICH_IPADDR_MAXMIND_GEOIP_ENABLE
-# environment variables are set to true, enable the corresponding service and provide a MaxMind acount id and license key:
+# environment variables are set to true, enable the corresponding service and provide a MaxMind account id and license key:
 # https://dev.maxmind.com/geoip/geolite2-free-geolocation-data
 maxmind:
   # Specifies whether a secret should be created for the maxmind license key.
   createSecret: false
   # Secret name to be used for the license. If empty, the secret name defaults to `maxmind-license`
-  # If no secret with a matching name exists, the value will be set from `licenseKey`.instead.
+  # If no secret with a matching name exists, the value will be set from `licenseKey` instead.
   secretRef: "maxmind-license"
   # Enabling asn will look up the autonomous system number and autonomous system
   # organization associated with IPv4 and IPv6 addresses.
@@ -138,7 +138,7 @@ serviceAccount:
   # If not set and create is true, a name is generated using the fullname template
   name: ""
 
-# global common labels, applied to all ressources
+# global common labels, applied to all resources
 commonLabels: {}
 
 podAnnotations: {}


### PR DESCRIPTION
## Summary
- correct spelling errors in `values.yaml`

## Testing
- `codespell charts/netobserv/values.yaml`


------
https://chatgpt.com/codex/tasks/task_e_684d1c4536c08324bbfe2235be375cb0