### PR TITLE
Add Splunk HEC configuration

### DIFF
--- a/charts/netobserv/templates/_helpers.tpl
+++ b/charts/netobserv/templates/_helpers.tpl
@@ -69,26 +69,28 @@ Create the name of the service account to use
 Determine if volumes need to be created
 */}}
 {{- define "volumesEnabled" -}}
-  {{- or
-    .Values.maxmind.asnEnabled
-    .Values.maxmind.geoipEnabled
-    .Values.outputKafka.tls.enabled
-    .Values.outputElasticsearch.tls.enabled
-    .Values.outputOpenSearch.tls.enabled
-    (not (empty .Values.extraVolumes))
-  -}}
+    {{- or
+      .Values.maxmind.asnEnabled
+      .Values.maxmind.geoipEnabled
+      .Values.outputKafka.tls.enabled
+      .Values.outputElasticsearch.tls.enabled
+      .Values.outputOpenSearch.tls.enabled
+      .Values.outputSplunkHec.tls.enabled
+      (not (empty .Values.extraVolumes))
+    -}}
 {{- end -}}
 
 {{/*
 Determine if volumeMounts need to be created
 */}}
 {{- define "volumeMountsEnabled" -}}
-  {{- or
-    .Values.maxmind.asnEnabled
-    .Values.maxmind.geoipEnabled
-    .Values.outputKafka.tls.enabled
-    .Values.outputElasticsearch.tls.enabled
-    .Values.outputOpenSearch.tls.enabled
-    (not (empty .Values.extraVolumeMounts))
-  -}}
+    {{- or
+      .Values.maxmind.asnEnabled
+      .Values.maxmind.geoipEnabled
+      .Values.outputKafka.tls.enabled
+      .Values.outputElasticsearch.tls.enabled
+      .Values.outputOpenSearch.tls.enabled
+      .Values.outputSplunkHec.tls.enabled
+      (not (empty .Values.extraVolumeMounts))
+    -}}
 {{- end -}}

--- a/charts/netobserv/templates/deployment.yaml
+++ b/charts/netobserv/templates/deployment.yaml
@@ -135,6 +135,27 @@ spec:
               value: "{{ .Values.outputKafka.tls.caMountPath }}/{{ .Values.outputKafka.tls.caFileName }}"
           {{- end }}
           {{- end }}
+          {{- if .Values.outputSplunkHec.enabled }}
+            - name: EF_OUTPUT_SPLUNK_HEC_ENABLE
+              value: 'true'
+            - name: EF_OUTPUT_SPLUNK_HEC_URL
+              value: {{ .Values.outputSplunkHec.url | quote }}
+            - name: EF_OUTPUT_SPLUNK_HEC_TOKEN
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.outputSplunkHec.tokenSecretRef }}
+                  key: {{ .Values.outputSplunkHec.tokenSecretKey }}
+            {{- if .Values.outputSplunkHec.index }}
+            - name: EF_OUTPUT_SPLUNK_HEC_INDEX
+              value: {{ .Values.outputSplunkHec.index }}
+            {{- end }}
+            {{- if .Values.outputSplunkHec.tls.enabled }}
+            - name: EF_OUTPUT_SPLUNK_HEC_TLS_ENABLE
+              value: 'true'
+            - name: "EF_OUTPUT_SPLUNK_HEC_TLS_CA_CERT_FILEPATH"
+              value: "{{ .Values.outputSplunkHec.tls.caMountPath }}/{{ .Values.outputSplunkHec.tls.caFileName }}"
+            {{- end }}
+          {{- end }}
           ports: {{ .Values.ports | toYaml | nindent 12 }}
           {{- if .Values.livenessProbe.enabled }}
           livenessProbe:
@@ -165,6 +186,11 @@ spec:
             {{- if .Values.outputOpenSearch.tls.enabled }}
             - name: {{ .Values.outputOpenSearch.tls.caConfigMap }}
               mountPath: {{ .Values.outputOpenSearch.tls.caMountPath }}
+              readOnly: True
+            {{- end }}
+            {{- if .Values.outputSplunkHec.tls.enabled }}
+            - name: {{ .Values.outputSplunkHec.tls.caConfigMap }}
+              mountPath: {{ .Values.outputSplunkHec.tls.caMountPath }}
               readOnly: True
             {{- end }}
             {{- if .Values.extraVolumeMounts }}
@@ -228,6 +254,14 @@ spec:
             items:
               - key: {{ .Values.outputOpenSearch.tls.caConfigMapKey }}
                 path: {{ .Values.outputOpenSearch.tls.caFileName }}
+        {{- end }}
+        {{- if .Values.outputSplunkHec.tls.enabled }}
+        - name: {{ .Values.outputSplunkHec.tls.caConfigMap }}
+          configMap:
+            name: {{ .Values.outputSplunkHec.tls.caConfigMap }}
+            items:
+              - key: {{ .Values.outputSplunkHec.tls.caConfigMapKey }}
+                path: {{ .Values.outputSplunkHec.tls.caFileName }}
         {{- end }}
       {{- end }}
       {{- if .Values.extraVolumes }}

--- a/charts/netobserv/values.yaml
+++ b/charts/netobserv/values.yaml
@@ -90,6 +90,32 @@ outputKafka:
     # The name of the file that contains the CA certificate.
     caFileName: "ca.crt"
 
+# The Splunk output can be used to send records via the Splunk HTTP
+# Event Collector (HEC).
+# https://docs.elastiflow.com/docs/data_platforms/splunk/datainput_and_index
+outputSplunkHec:
+  # Enable/disable the use of the Splunk HEC output.
+  enabled: false
+  # URL of the Splunk HEC endpoint including protocol and port.
+  url: ""
+  # Secret name containing the HEC token.
+  tokenSecretRef: "splunk-hec-token"
+  # The key in the secret that stores the HEC token.
+  tokenSecretKey: token
+  # Optional Splunk index to use when sending events.
+  index: ""
+  tls:
+    # Enable/disable TLS connections to Splunk HEC.
+    enabled: false
+    # The name of the config map that contains the CA certificate.
+    caConfigMap: ""
+    # The path to the CA certificate file.
+    caMountPath: ""
+    # The key in the config map that contains the CA certificate.
+    caConfigMapKey: "ca.crt"
+    # The name of the file that contains the CA certificate.
+    caFileName: "ca.crt"
+
 license:
   # Specifies whether a secret should be created. If you don't have a license, no need to create a license secret.
   createSecret: false


### PR DESCRIPTION
## Summary
- add `outputSplunkHec` section to values.yaml
- include Splunk TLS settings in volume helpers
- configure Splunk HEC environment vars and volumes in deployment template

## Testing
- `pre-commit run --files charts/netobserv/values.yaml charts/netobserv/templates/_helpers.tpl`

------
https://chatgpt.com/codex/tasks/task_e_684d1b23ac18832487bba5ae8652b207