### PR TITLE
Add Splunk HEC TLS skip verification option

### DIFF
--- a/charts/netobserv/templates/deployment.yaml
+++ b/charts/netobserv/templates/deployment.yaml
@@ -156,6 +156,10 @@ spec:
               value: 'true'
             - name: "EF_OUTPUT_SPLUNK_HEC_TLS_CA_CERT_FILEPATH"
               value: "{{ .Values.outputSplunkHec.tls.caMountPath }}/{{ .Values.outputSplunkHec.tls.caFileName }}"
+            {{- if .Values.outputSplunkHec.tls.skipVerification }}
+            - name: EF_OUTPUT_SPLUNK_HEC_TLS_SKIP_VERIFICATION
+              value: 'true'
+            {{- end }}
             {{- end }}
           {{- end }}
           ports: {{ .Values.ports | toYaml | nindent 12 }}

--- a/charts/netobserv/values.yaml
+++ b/charts/netobserv/values.yaml
@@ -115,6 +115,8 @@ outputSplunkHec:
     caConfigMapKey: "ca.crt"
     # The name of the file that contains the CA certificate.
     caFileName: "ca.crt"
+    # Skip verifying the Splunk HEC TLS certificate.
+    skipVerification: false
 
 license:
   # Specifies whether a secret should be created. If you don't have a license, no need to create a license secret.


### PR DESCRIPTION
## Summary
- support EF_OUTPUT_SPLUNK_HEC_TLS_SKIP_VERIFICATION env var

## Testing
- `yamllint -c lintconf.yaml $(git ls-files '*.yml' '*.yaml' | grep -v '^charts/netobserv/templates/')`
- `ct lint --chart-dirs charts --target-branch main --validate-maintainers=false --chart-yaml-schema etc/chart_schema.yaml` *(fails: 'chart_schema.yaml' not found)*

------
https://chatgpt.com/codex/tasks/task_e_684d938f4f3483248f5727740f48a13b