### PR TITLE
Fix TLS env injection

### DIFF
--- a/charts/netobserv/templates/_helpers.tpl
+++ b/charts/netobserv/templates/_helpers.tpl
@@ -72,10 +72,10 @@ Determine if volumes need to be created
     {{- or
       .Values.maxmind.asnEnabled
       .Values.maxmind.geoipEnabled
-      .Values.outputKafka.tls.enabled
-      .Values.outputElasticsearch.tls.enabled
-      .Values.outputOpenSearch.tls.enabled
-      .Values.outputSplunkHec.tls.enabled
+      (and .Values.outputKafka.tls.enabled .Values.outputKafka.tls.caConfigMap .Values.outputKafka.tls.caMountPath)
+      (and .Values.outputElasticsearch.tls.enabled .Values.outputElasticsearch.tls.caConfigMap .Values.outputElasticsearch.tls.caMountPath)
+      (and .Values.outputOpenSearch.tls.enabled .Values.outputOpenSearch.tls.caConfigMap .Values.outputOpenSearch.tls.caMountPath)
+      (and .Values.outputSplunkHec.tls.enabled .Values.outputSplunkHec.tls.caConfigMap .Values.outputSplunkHec.tls.caMountPath)
       (not (empty .Values.extraVolumes))
     -}}
 {{- end -}}
@@ -87,10 +87,10 @@ Determine if volumeMounts need to be created
     {{- or
       .Values.maxmind.asnEnabled
       .Values.maxmind.geoipEnabled
-      .Values.outputKafka.tls.enabled
-      .Values.outputElasticsearch.tls.enabled
-      .Values.outputOpenSearch.tls.enabled
-      .Values.outputSplunkHec.tls.enabled
+      (and .Values.outputKafka.tls.enabled .Values.outputKafka.tls.caConfigMap .Values.outputKafka.tls.caMountPath)
+      (and .Values.outputElasticsearch.tls.enabled .Values.outputElasticsearch.tls.caConfigMap .Values.outputElasticsearch.tls.caMountPath)
+      (and .Values.outputOpenSearch.tls.enabled .Values.outputOpenSearch.tls.caConfigMap .Values.outputOpenSearch.tls.caMountPath)
+      (and .Values.outputSplunkHec.tls.enabled .Values.outputSplunkHec.tls.caConfigMap .Values.outputSplunkHec.tls.caMountPath)
       (not (empty .Values.extraVolumeMounts))
     -}}
 {{- end -}}

--- a/charts/netobserv/templates/deployment.yaml
+++ b/charts/netobserv/templates/deployment.yaml
@@ -95,8 +95,10 @@ spec:
           {{- if .Values.outputElasticsearch.tls.enabled }}
             - name: EF_OUTPUT_ELASTICSEARCH_TLS_ENABLE
               value: 'true'
+            {{- if and .Values.outputElasticsearch.tls.caConfigMap .Values.outputElasticsearch.tls.caMountPath }}
             - name: "EF_OUTPUT_ELASTICSEARCH_TLS_CA_CERT_FILEPATH"
               value: "{{ .Values.outputElasticsearch.tls.caMountPath }}/{{ .Values.outputElasticsearch.tls.caFileName }}"
+            {{- end }}
           {{- end }}
           {{- end }}
           {{- if .Values.outputOpenSearch.enabled }}
@@ -114,8 +116,10 @@ spec:
           {{- if .Values.outputOpenSearch.tls.enabled }}
             - name: EF_OUTPUT_OPENSEARCH_TLS_ENABLE
               value: 'true'
+            {{- if and .Values.outputOpenSearch.tls.caConfigMap .Values.outputOpenSearch.tls.caMountPath }}
             - name: "EF_OUTPUT_OPENSEARCH_TLS_CA_CERT_FILEPATH"
               value: "{{ .Values.outputOpenSearch.tls.caMountPath }}/{{ .Values.outputOpenSearch.tls.caFileName }}"
+            {{- end }}
           {{- end }}
           {{- end }}
           {{- if .Values.license.createSecret }}
@@ -133,8 +137,10 @@ spec:
           {{- if .Values.outputKafka.tls.enabled }}
             - name: EF_OUTPUT_KAFKA_TLS_ENABLE
               value: 'true'
+            {{- if and .Values.outputKafka.tls.caConfigMap .Values.outputKafka.tls.caMountPath }}
             - name: "EF_OUTPUT_KAFKA_TLS_CA_CERT_FILEPATH"
               value: "{{ .Values.outputKafka.tls.caMountPath }}/{{ .Values.outputKafka.tls.caFileName }}"
+            {{- end }}
           {{- end }}
           {{- end }}
           {{- if .Values.outputSplunkHec.enabled }}
@@ -154,8 +160,10 @@ spec:
             {{- if .Values.outputSplunkHec.tls.enabled }}
             - name: EF_OUTPUT_SPLUNK_HEC_TLS_ENABLE
               value: 'true'
+            {{- if and .Values.outputSplunkHec.tls.caConfigMap .Values.outputSplunkHec.tls.caMountPath }}
             - name: "EF_OUTPUT_SPLUNK_HEC_TLS_CA_CERT_FILEPATH"
               value: "{{ .Values.outputSplunkHec.tls.caMountPath }}/{{ .Values.outputSplunkHec.tls.caFileName }}"
+            {{- end }}
             {{- if .Values.outputSplunkHec.tls.skipVerification }}
             - name: EF_OUTPUT_SPLUNK_HEC_TLS_SKIP_VERIFICATION
               value: 'true'
@@ -180,22 +188,22 @@ spec:
             - name: geolite2-data
               mountPath: /etc/elastiflow/maxmind
             {{- end }}
-            {{- if .Values.outputKafka.tls.enabled }}
+            {{- if and .Values.outputKafka.tls.enabled .Values.outputKafka.tls.caConfigMap .Values.outputKafka.tls.caMountPath }}
             - name: {{ .Values.outputKafka.tls.caConfigMap }}
               mountPath: {{ .Values.outputKafka.tls.caMountPath }}
               readOnly: True
             {{- end }}
-            {{- if .Values.outputElasticsearch.tls.enabled }}
+            {{- if and .Values.outputElasticsearch.tls.enabled .Values.outputElasticsearch.tls.caConfigMap .Values.outputElasticsearch.tls.caMountPath }}
             - name: {{ .Values.outputElasticsearch.tls.caConfigMap }}
               mountPath: {{ .Values.outputElasticsearch.tls.caMountPath }}
               readOnly: True
             {{- end }}
-            {{- if .Values.outputOpenSearch.tls.enabled }}
+            {{- if and .Values.outputOpenSearch.tls.enabled .Values.outputOpenSearch.tls.caConfigMap .Values.outputOpenSearch.tls.caMountPath }}
             - name: {{ .Values.outputOpenSearch.tls.caConfigMap }}
               mountPath: {{ .Values.outputOpenSearch.tls.caMountPath }}
               readOnly: True
             {{- end }}
-            {{- if .Values.outputSplunkHec.tls.enabled }}
+            {{- if and .Values.outputSplunkHec.tls.enabled .Values.outputSplunkHec.tls.caConfigMap .Values.outputSplunkHec.tls.caMountPath }}
             - name: {{ .Values.outputSplunkHec.tls.caConfigMap }}
               mountPath: {{ .Values.outputSplunkHec.tls.caMountPath }}
               readOnly: True
@@ -238,7 +246,7 @@ spec:
         - name: geolite2-data
           emptyDir: {}
         {{- end }}
-        {{- if .Values.outputKafka.tls.enabled }}
+        {{- if and .Values.outputKafka.tls.enabled .Values.outputKafka.tls.caConfigMap .Values.outputKafka.tls.caMountPath }}
         - name: {{ .Values.outputKafka.tls.caConfigMap }}
           configMap:
             name: {{ .Values.outputKafka.tls.caConfigMap }}
@@ -246,7 +254,7 @@ spec:
               - key: {{ .Values.outputKafka.tls.caConfigMapKey }}
                 path: {{ .Values.outputKafka.tls.caFileName }}
         {{- end }}
-        {{- if .Values.outputElasticsearch.tls.enabled }}
+        {{- if and .Values.outputElasticsearch.tls.enabled .Values.outputElasticsearch.tls.caConfigMap .Values.outputElasticsearch.tls.caMountPath }}
         - name: {{ .Values.outputElasticsearch.tls.caConfigMap }}
           configMap:
             name: {{ .Values.outputElasticsearch.tls.caConfigMap }}
@@ -254,7 +262,7 @@ spec:
               - key: {{ .Values.outputElasticsearch.tls.caConfigMapKey }}
                 path: {{ .Values.outputElasticsearch.tls.caFileName }}
         {{- end }}
-        {{- if .Values.outputOpenSearch.tls.enabled }}
+        {{- if and .Values.outputOpenSearch.tls.enabled .Values.outputOpenSearch.tls.caConfigMap .Values.outputOpenSearch.tls.caMountPath }}
         - name: {{ .Values.outputOpenSearch.tls.caConfigMap }}
           configMap:
             name: {{ .Values.outputOpenSearch.tls.caConfigMap }}
@@ -262,7 +270,7 @@ spec:
               - key: {{ .Values.outputOpenSearch.tls.caConfigMapKey }}
                 path: {{ .Values.outputOpenSearch.tls.caFileName }}
         {{- end }}
-        {{- if .Values.outputSplunkHec.tls.enabled }}
+        {{- if and .Values.outputSplunkHec.tls.enabled .Values.outputSplunkHec.tls.caConfigMap .Values.outputSplunkHec.tls.caMountPath }}
         - name: {{ .Values.outputSplunkHec.tls.caConfigMap }}
           configMap:
             name: {{ .Values.outputSplunkHec.tls.caConfigMap }}


### PR DESCRIPTION
## Summary
- skip CA env variables when TLS certificate not provided

## Testing
- `yamllint -c lintconf.yaml $(git ls-files '*.yml' '*.yaml' | grep -v '^charts/netobserv/templates/')`
- `ct lint --target-branch main --validate-maintainers=false` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684da3886cd0832483007f7938b9191e