### PR TITLE
Fix Splunk HEC env var

### DIFF
--- a/charts/netobserv/templates/deployment.yaml
+++ b/charts/netobserv/templates/deployment.yaml
@@ -146,7 +146,7 @@ spec:
           {{- if .Values.outputSplunkHec.enabled }}
             - name: EF_OUTPUT_SPLUNK_HEC_ENABLE
               value: 'true'
-            - name: EF_OUTPUT_SPLUNK_HEC_URL
+            - name: EF_OUTPUT_SPLUNK_HEC_ADDRESSES
               value: {{ .Values.outputSplunkHec.url | quote }}
             - name: EF_OUTPUT_SPLUNK_HEC_TOKEN
               valueFrom:


### PR DESCRIPTION
## Summary
- fix environment variable name for Splunk HEC output

## Testing
- `pre-commit run trailing-whitespace --files charts/netobserv/templates/deployment.yaml`
- `pre-commit run end-of-file-fixer --files charts/netobserv/templates/deployment.yaml`
- `pre-commit run check-merge-conflict --files charts/netobserv/templates/deployment.yaml`
- `yamllint -c lintconf.yaml $(git ls-files '*.yml' '*.yaml' | grep -v '^charts/netobserv/templates/')`
- `helm lint charts/netobserv`
- `helm template test charts/netobserv`

------
https://chatgpt.com/codex/tasks/task_e_684e44c9ede88324a137e002e0fd2417