### PR TITLE
Fix indentation for EF_ACCOUNT_ID in deployment template

### DIFF
--- a/charts/netobserv/templates/deployment.yaml
+++ b/charts/netobserv/templates/deployment.yaml
@@ -77,7 +77,7 @@ spec:
             {{- toYaml . | nindent 12 }}
           {{- end }}
           {{- if .Values.license.accountId }}
-          - name: EF_ACCOUNT_ID
+            - name: EF_ACCOUNT_ID
               value: {{ .Values.license.accountId }}
           {{- end }}
           {{- if .Values.outputElasticsearch.enabled }}


### PR DESCRIPTION
## Summary
- fix indentation in deployment for EF_ACCOUNT_ID

## Testing
- `yamllint -c lintconf.yaml $(git ls-files '*.yml' '*.yaml' | grep -v '^charts/netobserv/templates/')`
- `helm lint charts/netobserv`
- `helm template test charts/netobserv --set license.accountId=foo --debug --show-only templates/deployment.yaml`

------
https://chatgpt.com/codex/tasks/task_e_684e6261ed2c8324b1f052f5906fbf68